### PR TITLE
Hdim 512 testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -422,6 +422,14 @@ def get_extensions():
     elif torch.version.hip and (
         torch.cuda.is_available() or os.getenv("HIP_ARCHITECTURES", "") != ""
     ):
+        enable_hd512_hip_fmha = os.getenv("ENABLE_HD512_HIP_FMHA", "0")
+        if enable_hd512_hip_fmha != "1":
+            source_hip_maxk_512 = []
+            for ff in source_hip:
+                if ff.endswith("maxk_512.cpp"):
+                    source_hip_maxk_512 += [ff]
+            source_hip = list(set(source_hip) - set(source_hip_maxk_512))
+
         rename_cpp_cu(source_hip)
         hip_version = get_hip_version(ROCM_HOME)
 
@@ -441,6 +449,8 @@ def get_extensions():
         ]
 
         generator_flag = []
+        if enable_hd512_hip_fmha == "1":
+            generator_flag += ["-DFMHA_LIMIT_MAX_HEADDIM_TO_256=0"]
 
         cc_flag = ["-DBUILD_PYTHON_PACKAGE"]
         use_rtn_bf16_convert = os.getenv("ENABLE_HIP_FMHA_RTN_BF16_CONVERT", "0")

--- a/setup.py
+++ b/setup.py
@@ -422,14 +422,6 @@ def get_extensions():
     elif torch.version.hip and (
         torch.cuda.is_available() or os.getenv("HIP_ARCHITECTURES", "") != ""
     ):
-        disable_hd256_hip_fmha = os.getenv("DISABLE_HD256_HIP_FMHA", "0")
-        if disable_hd256_hip_fmha == "1":
-            source_hip_maxk_256 = []
-            for ff in source_hip:
-                if ff.endswith("maxk_256.cpp"):
-                    source_hip_maxk_256 += [ff]
-            source_hip = list(set(source_hip) - set(source_hip_maxk_256))
-
         rename_cpp_cu(source_hip)
         hip_version = get_hip_version(ROCM_HOME)
 
@@ -449,8 +441,6 @@ def get_extensions():
         ]
 
         generator_flag = []
-        if disable_hd256_hip_fmha == "1":
-            generator_flag += ["-DFMHA_SUPPORT_MAX_HEADDIM_128=1"]
 
         cc_flag = ["-DBUILD_PYTHON_PACKAGE"]
         use_rtn_bf16_convert = os.getenv("ENABLE_HIP_FMHA_RTN_BF16_CONVERT", "0")

--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -462,6 +462,16 @@ def test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed, fmt, **kwargs)
     if fmt == "BMK" and not fmha.common._is_bias_type_supported_in_BMK(bias_type):
         pytest.skip("BMK incompatible with this bias")
 
+    if op is fmha.ck.FwOp:
+        if (k > 256 or kv > 256) and issubclass(
+            bias_type,
+            (
+                fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            ),
+        ):
+            pytest.skip("ck.FwOp hdim-512 is not supported when Paged-KVCache is used!")
+
     query, key, value, attn_bias = create_tensors(
         *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
         fmt="BMHK" if packed else fmt,

--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -472,6 +472,11 @@ def test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed, fmt, **kwargs)
         ):
             pytest.skip("ck.FwOp hdim-512 is not supported when Paged-KVCache is used!")
 
+    # comment this for testing hdim-512 cases if hdim-512 support is built into hip_fmha
+    if op is fmha.ck.FwOp:
+        if k > 256 or kv > 256:
+            pytest.skip("ck.FwOp hdim-512 support is not built by default!")
+
     query, key, value, attn_bias = create_tensors(
         *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
         fmt="BMHK" if packed else fmt,

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_selector.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_selector.h
@@ -47,6 +47,10 @@ static std::pair<bool, int> get_num_kv_splits_heuristic(
   mtile_size_for_splitkv_smallq =
       get_mtile_size_for_splitkv_smallq(max_headdim);
 
+  // hdim-512 is not supported by splitkv-kernel at present
+  if (max_headdim > 256)
+    return std::make_pair(false, 1);
+
   if (max_seqlen_q >= mtile_size_for_pipeline_default) {
     int batch_nhead_mblocks = num_batches * num_heads *
         ceildiv(max_seqlen_q, mtile_size_for_pipeline_default);

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
@@ -9,52 +9,6 @@
 #include <ck_tile/core.hpp>
 #include <stdexcept>
 
-#ifndef FMHA_SUPPORT_MAX_HEADDIM_128
-#define FMHA_SUPPORT_MAX_HEADDIM_128 0
-#endif
-
-#if FMHA_SUPPORT_MAX_HEADDIM_128
-
-#define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
-  [&] {                                                                \
-    if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
-      constexpr ck_tile::index_t CONST_NAME = 32;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 64;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 96;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
-      constexpr ck_tile::index_t CONST_NAME = 128;                     \
-      __VA_ARGS__();                                                   \
-    } else {                                                           \
-      throw std::runtime_error("Head-dim sizes not supported!");       \
-    }                                                                  \
-  }()
-
-#define FMHA_BWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
-  [&] {                                                                \
-    if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
-      constexpr ck_tile::index_t CONST_NAME = 32;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 64;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 96;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
-      constexpr ck_tile::index_t CONST_NAME = 128;                     \
-      __VA_ARGS__();                                                   \
-    } else {                                                           \
-      throw std::runtime_error("Head-dim sizes not supported!");       \
-    }                                                                  \
-  }()
-
-#else
-
 #define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
   [&] {                                                                \
     if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
@@ -101,5 +55,3 @@
       throw std::runtime_error("Head-dim sizes not supported!");       \
     }                                                                  \
   }()
-
-#endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
@@ -9,6 +9,36 @@
 #include <ck_tile/core.hpp>
 #include <stdexcept>
 
+#ifndef FMHA_LIMIT_MAX_HEADDIM_TO_256
+#define FMHA_LIMIT_MAX_HEADDIM_TO_256 1
+#endif
+
+#if FMHA_LIMIT_MAX_HEADDIM_TO_256
+
+#define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
+  [&] {                                                                \
+    if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
+      constexpr ck_tile::index_t CONST_NAME = 32;                      \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
+      constexpr ck_tile::index_t CONST_NAME = 64;                      \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
+      constexpr ck_tile::index_t CONST_NAME = 96;                      \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
+      constexpr ck_tile::index_t CONST_NAME = 128;                     \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 256 && HEAD_DIM2 <= 256) {                 \
+      constexpr ck_tile::index_t CONST_NAME = 256;                     \
+      __VA_ARGS__();                                                   \
+    } else {                                                           \
+      throw std::runtime_error("Head-dim sizes not supported!");       \
+    }                                                                  \
+  }()
+
+#else
+
 #define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
   [&] {                                                                \
     if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
@@ -33,6 +63,8 @@
       throw std::runtime_error("Head-dim sizes not supported!");       \
     }                                                                  \
   }()
+
+#endif
 
 #define FMHA_BWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
   [&] {                                                                \

--- a/xformers/csrc/attention/hip_fmha/generate_instances.py
+++ b/xformers/csrc/attention/hip_fmha/generate_instances.py
@@ -354,15 +354,15 @@ def create_backward_instances_ref(instance_dir: Path, headdims: List) -> None:
 
 
 if __name__ == "__main__":
-    disable_hd256 = False
+    disable_hd512 = False
 
     for arg in sys.argv:
-        if arg == "--ignore-hd256":
-            disable_hd256 = True
+        if arg == "--ignore-hd512":
+            disable_hd512 = True
 
-    if disable_hd256:
-        headdims_fwd = [32, 64, 96, 128]
-        headdims_bwd = [32, 64, 96, 128]
+    if disable_hd512:
+        headdims_fwd = [32, 64, 96, 128, 256]
+        headdims_bwd = [32, 64, 96, 128, 256]
     else:
         headdims_fwd = [32, 64, 96, 128, 256, 512]
         headdims_bwd = [32, 64, 96, 128, 256]


### PR DESCRIPTION
This PR made the following udpates:
1.  Skip the testing when attn_bias_type is PageAttention related since the PageKVCache is only supported by split-kv kernel
2. Update to the kernel selector so that hdim-512 is only used with the non-splitkv kernel since the splitkv kernel and pipelines does not support hdim-512
3. Remove using the DISABLE_HD256_HIP_FMHA env-variable and add using ENABLE_HD512_HIP_FMHA env-variable.  HD512 by default will not be built 
